### PR TITLE
編集ボタンを隠れないようにする

### DIFF
--- a/src/polymer-jp-marked.html
+++ b/src/polymer-jp-marked.html
@@ -25,6 +25,10 @@
       :host {
         display: block;
       }
+      app-toolbar {
+        padding: 16px;
+        height: auto;
+      }
       app-toolbar paper-icon-button {
         color: white;
       }
@@ -54,7 +58,6 @@
         font-family: serif;
         font-size: 24px;
         font-weight: 700;
-        white-space: nowrap;
       }
       /* TODO: 幅調整 */
       marked-element {


### PR DESCRIPTION
https://github.com/Polymer-Japan/polymer-jp.org/issues/18
上記issue対応

![kapture 2017-11-16 at 0 48 02](https://user-images.githubusercontent.com/9045135/32845414-f95421e8-ca67-11e7-9901-e73881d8b953.gif)

改行するようにして、画面幅が小さくなってもアイコンが隠れないようにしてみました。