### PR TITLE
Create title component

### DIFF
--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -22,6 +22,7 @@
       }
       .svg-logo {
         height: 24px;
+        width: 100%;
         vertical-align: middle;
         margin-right: 12px;
       }

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../bower_components/paper-badge/paper-badge.html">
 
 <dom-module id="polymer-jp-title">
@@ -8,13 +9,13 @@
         display: inline-block;
       }
       .area-small {
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        @apply --layout-horizontal;
+        @apply --layout-center;
+        @apply --layout-center-justified;
       }
       .link {
-        display: flex;
-        align-items: center;
+        @apply --layout-horizontal;
+        @apply --layout-center;
         text-decoration: none;
         padding: 10px 0;
       }

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -1,0 +1,34 @@
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<script>
+  class PolymerJpTitle extends Polymer.Element {
+    static get is() { return 'polymer-jp-title'; }
+    static get template() {
+      return `
+<style>
+.area {
+  display: flex;
+  text-decoration: none;
+  color: #000;
+  padding: 10px 0;
+}
+.logo {
+  height: 24px;
+  margin: 0px 12px 0px 0px;
+  vertical-align: middle;
+}
+.text {
+  white-space: nowrap;
+  font-size: 22px;
+  margin: 0;
+}
+</style>
+<a href="/" class="area">
+  <img class="logo" src="/assets/logos/polymer-jp-logo-mark.svg">
+  <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
+</a>
+      `;
+    }
+  }
+  customElements.define(PolymerJpTitle.is, PolymerJpTitle);
+</script>

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -14,6 +14,7 @@
       }
       .link {
         display: flex;
+        align-items: center;
         text-decoration: none;
         padding: 10px 0;
       }

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -7,18 +7,32 @@
       .area {
         display: flex;
         text-decoration: none;
-        color: #000;
         padding: 10px 0;
       }
-      .logo {
+      .area.small {
+        justify-content: center;
+        align-items: center;
+      }
+      .svg-logo {
         height: 24px;
-        margin: 0px 12px 0px 0px;
         vertical-align: middle;
+        margin-right: 12px;
+      }
+      .iron-logo {
+        height: 26px;
+        width: 26px;
+        color: #fff;
+        margin-right: 6px;
       }
       .text {
         white-space: nowrap;
         font-size: 22px;
         margin: 0;
+        color: #000;
+      }
+      .area.small .text {
+        font-size: 18px;
+        color: #fff;
       }
       paper-badge {
         --paper-badge-width: 45px;
@@ -28,14 +42,30 @@
         }
       }
     </style>
-    <a href="/" class="area">
-      <img class="logo" src="/assets/logos/polymer-jp-logo-mark.svg">
-      <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
-    </a>
+    <template is="dom-if" if="{{!small}}">
+      <a href="/" class="area">
+        <img class="svg-logo" src="/assets/logos/polymer-jp-logo-mark.svg">
+        <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
+      </a>
+    </template>
+    <template is="dom-if" if="{{small}}">
+      <div class="area small">
+        <iron-icon class="iron-logo" icon="i:polymer"></iron-icon>
+        <p class="text">Polymer Japan</p>
+      </div>
+    </template>
   </template>
   <script>
     class PolymerJpTitle extends Polymer.Element {
       static get is() { return 'polymer-jp-title'; }
+      static get properties() {
+        return {
+          small: {
+            type: Boolean,
+            value: false
+          }
+        }
+      }
       ready() {
         super.ready();
         // BUG: 初期読み込み時にずれる時があるので時間差で表示

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -1,34 +1,50 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/paper-badge/paper-badge.html">
 
-<script>
-  class PolymerJpTitle extends Polymer.Element {
-    static get is() { return 'polymer-jp-title'; }
-    static get template() {
-      return `
-<style>
-.area {
-  display: flex;
-  text-decoration: none;
-  color: #000;
-  padding: 10px 0;
-}
-.logo {
-  height: 24px;
-  margin: 0px 12px 0px 0px;
-  vertical-align: middle;
-}
-.text {
-  white-space: nowrap;
-  font-size: 22px;
-  margin: 0;
-}
-</style>
-<a href="/" class="area">
-  <img class="logo" src="/assets/logos/polymer-jp-logo-mark.svg">
-  <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
-</a>
-      `;
+<dom-module id="polymer-jp-title">
+  <template>
+    <style>
+      .area {
+        display: flex;
+        text-decoration: none;
+        color: #000;
+        padding: 10px 0;
+      }
+      .logo {
+        height: 24px;
+        margin: 0px 12px 0px 0px;
+        vertical-align: middle;
+      }
+      .text {
+        white-space: nowrap;
+        font-size: 22px;
+        margin: 0;
+      }
+      paper-badge {
+        --paper-badge-width: 45px;
+        --paper-badge: {
+          border-radius: 10px;
+          font-weight: bold;
+        }
+      }
+    </style>
+    <a href="/" class="area">
+      <img class="logo" src="/assets/logos/polymer-jp-logo-mark.svg">
+      <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
+    </a>
+  </template>
+  <script>
+    class PolymerJpTitle extends Polymer.Element {
+      static get is() { return 'polymer-jp-title'; }
+      ready() {
+        super.ready();
+        // BUG: 初期読み込み時にずれる時があるので時間差で表示
+        Polymer.Async.timeOut.run( _ => {
+          this.shadowRoot.querySelector('paper-badge').hidden = false;
+          this.shadowRoot.querySelector('paper-badge').updatePosition();
+        }, 1000);
+      }
     }
-  }
-  customElements.define(PolymerJpTitle.is, PolymerJpTitle);
-</script>
+    customElements.define(PolymerJpTitle.is, PolymerJpTitle);
+  </script>
+</dom-module>

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -5,13 +5,17 @@
   <template>
     <style>
       .area {
+        display: inline-block;
+      }
+      .area-small {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+      .link {
         display: flex;
         text-decoration: none;
         padding: 10px 0;
-      }
-      .area.small {
-        justify-content: center;
-        align-items: center;
       }
       .svg-logo {
         height: 24px;
@@ -30,7 +34,7 @@
         margin: 0;
         color: #000;
       }
-      .area.small .text {
+      .area-small .text {
         font-size: 18px;
         color: #fff;
       }
@@ -43,13 +47,15 @@
       }
     </style>
     <template is="dom-if" if="{{!small}}">
-      <a href="/" class="area">
-        <img class="svg-logo" src="/assets/logos/polymer-jp-logo-mark.svg">
-        <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
-      </a>
+      <div class="area">
+        <a href="/" class="link">
+          <img class="svg-logo" src="/assets/logos/polymer-jp-logo-mark.svg">
+          <p class="text">Polymer Japan <paper-badge label="BETA" hidden></paper-badge></p>
+        </a>
+      </div>
     </template>
     <template is="dom-if" if="{{small}}">
-      <div class="area small">
+      <div class="area-small">
         <iron-icon class="iron-logo" icon="i:polymer"></iron-icon>
         <p class="text">Polymer Japan</p>
       </div>

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -22,7 +22,7 @@
       }
       .svg-logo {
         height: 24px;
-        width: 100%;
+        width: 35px;
         vertical-align: middle;
         margin-right: 12px;
       }

--- a/src/polymer-jp-title.html
+++ b/src/polymer-jp-title.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/paper-badge/paper-badge.html">
 
 <dom-module id="polymer-jp-title">

--- a/src/polymer-jp.html
+++ b/src/polymer-jp.html
@@ -29,6 +29,7 @@
 
 <link rel="import" href="polymer-jp-gtm.html">
 <link rel="import" href="polymer-jp-icons.html">
+<link rel="import" href="polymer-jp-title.html">
 
 <dom-module id="polymer-jp">
   <template>
@@ -100,15 +101,6 @@
       }
       polymer-jp-marked {
         min-height: 80vh;
-      }
-      .logo {
-        height: 24px;
-        margin: 0px 12px 0px 0px;
-        vertical-align: middle;
-      }
-      div[main-title] {
-        white-space: nowrap;
-        font-size: 22px;
       }
       .back-toolbar {
         background: #337ab7 url(/assets/textures/section-gradient-light.png) repeat-x center bottom;
@@ -197,8 +189,7 @@
           <template is="dom-if" if="[[smallScreen]]">
             <paper-icon-button class="menu" icon="i:[[_menu]]" on-tap="_drawerToggle"></paper-icon-button>
           </template>
-          <a href="/"><img class="logo" src="/assets/logos/polymer-jp-logo-mark.svg" drawer-toggle></a>
-          <div main-title><span>Polymer Japan <paper-badge label="BETA" hidden></paper-badge></span></div>
+          <polymer-jp-title></polymer-jp-title>
           <div class="flex"></div>
           <template is="dom-if" if="[[!smallScreen]]">
             <nav>

--- a/src/polymer-jp.html
+++ b/src/polymer-jp.html
@@ -104,19 +104,6 @@
         background: #337ab7 url(/assets/textures/section-gradient-light.png) repeat-x center bottom;
         background-size: 10px;
       }
-      .back-logo {
-        color: white;
-        margin-right: 6px;
-        height: 32px;
-        width: 40px;
-      }
-      .back-text {
-        color: white;
-        font-size: 22px;
-        white-space: nowrap;
-        user-select: none;
-        cursor: default;
-      }
       nav {
         @apply --layout-horizontal;
         @apply --layout-center;

--- a/src/polymer-jp.html
+++ b/src/polymer-jp.html
@@ -51,6 +51,9 @@
         background-color: var(--app-background-color);
         color: var(--app-text-color);
       }
+      app-toolbar{
+        @apply --layout-horizontal;
+      }
       app-toolbar paper-icon-button {
         color: #6b6b6b;
       }
@@ -102,6 +105,9 @@
       polymer-jp-marked {
         min-height: 80vh;
       }
+      polymer-jp-title {
+        @apply(--layout-flex);
+      }
       .back-toolbar {
         background: #337ab7 url(/assets/textures/section-gradient-light.png) repeat-x center bottom;
         background-size: 10px;
@@ -132,9 +138,6 @@
         box-sizing: border-box;
         text-decoration: none;
         color: #4d4d4d;
-      }
-      .flex {
-        @apply --layout-flex;
       }
       .menu {
         margin-left: -8px;
@@ -190,7 +193,6 @@
             <paper-icon-button class="menu" icon="i:[[_menu]]" on-tap="_drawerToggle"></paper-icon-button>
           </template>
           <polymer-jp-title></polymer-jp-title>
-          <div class="flex"></div>
           <template is="dom-if" if="[[!smallScreen]]">
             <nav>
               <iron-selector attr-for-selected="name" selected="{{_selectedId}}">

--- a/src/polymer-jp.html
+++ b/src/polymer-jp.html
@@ -10,7 +10,6 @@
 <link rel="import" href="../bower_components/app-route/app-location.html">
 <link rel="import" href="../bower_components/app-route/app-route.html">
 <link rel="import" href="../bower_components/app-storage/app-localstorage/app-localstorage-document.html">
-<link rel="import" href="../bower_components/iron-icon/iron-icon.html">
 <link rel="import" href="../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../bower_components/iron-media-query/iron-media-query.html">
 <link rel="import" href="../bower_components/iron-selector/iron-selector.html">

--- a/src/polymer-jp.html
+++ b/src/polymer-jp.html
@@ -206,8 +206,7 @@
           <app-drawer slot="drawer" swipe-open on-opened-changed="_iconMenu">
 
             <app-toolbar class="back-toolbar">
-              <a href="/"><iron-icon icon="i:polymer" class="back-logo"></iron-icon></a>
-              <div class="back-text">Polymer JP</div>
+              <polymer-jp-title small></polymer-jp-title>
             </app-toolbar>
 
             <paper-listbox attr-for-selected="name" selected="{{_selectedId}}">

--- a/src/polymer-jp.html
+++ b/src/polymer-jp.html
@@ -21,7 +21,6 @@
 <link rel="import" href="../bower_components/paper-listbox/paper-listbox.html">
 <link rel="import" href="../bower_components/paper-progress/paper-progress.html">
 <link rel="import" href="../bower_components/paper-toast/paper-toast.html">
-<link rel="import" href="../bower_components/paper-badge/paper-badge.html">
 <link rel="import" href="../bower_components/polymerfire/firebase-app.html">
 <link rel="import" href="../bower_components/polymerfire/firebase-messaging.html">
 <link rel="import" href="../bower_components/polymerfire/firestore-element.html">
@@ -94,13 +93,6 @@
         border-top: 1px solid #aaa;
         --paper-toast-background-color: white;
         --paper-toast-color: #555;
-      }
-      paper-badge {
-        --paper-badge-width: 45px;
-        --paper-badge: {
-          border-radius: 10px;
-          font-weight: bold;
-        }
       }
       polymer-jp-marked {
         min-height: 80vh;
@@ -333,12 +325,6 @@
             });
           });
         }
-
-        // BUG: 初期読み込み時にずれる時があるので
-        Polymer.Async.timeOut.run(_=>{
-          this.shadowRoot.querySelector('paper-badge').hidden=false;
-          this.shadowRoot.querySelector('paper-badge').updatePosition();
-        }, 1000);
 
         Polymer.importHref(this.importPath+"polymer-jp-marked.html");
         Polymer.importHref(this.importPath+"polymer-jp-inquery.html");


### PR DESCRIPTION
https://github.com/Polymer-Japan/polymer-jp.org/issues/24

# Changelog

ページタイトル部分のコンポーネントを作りました。
関連するソースはそっちへ移動。

- `<a>` で囲う範囲を変更して、テキスト部分もリンクエリアに（issue対応）
- iron-flex-layoutがうまく適用できてなかったのを修正
- スクロール時に表示される青背景のタイトルは、統一性を持たせるためデザイン変更

# スクリーンショット

## 通常

![image](https://user-images.githubusercontent.com/9045135/33760165-20898112-dc48-11e7-9428-9000f323be15.png)
↑見た目上の変化はナシ

### リンク範囲
![image](https://user-images.githubusercontent.com/9045135/33760823-7c9dee00-dc4a-11e7-940c-7ebc64ec2726.png)


## 青背景（smallプロパティ付与時）

|NEW|OLD|
|---|---|
|![image](https://user-images.githubusercontent.com/9045135/33760196-35d657ca-dc48-11e7-8510-186f4918245a.png)|![image](https://user-images.githubusercontent.com/9045135/33760211-42e4fc6e-dc48-11e7-9fc3-d6e25c168714.png)|

